### PR TITLE
Makes image comparator customizable.

### DIFF
--- a/dropshots/api/dropshots.api
+++ b/dropshots/api/dropshots.api
@@ -7,8 +7,8 @@ public final class com/dropbox/dropshots/BuildConfig {
 
 public final class com/dropbox/dropshots/Dropshots : org/junit/rules/TestRule {
 	public fun <init> ()V
-	public fun <init> (Lkotlin/jvm/functions/Function1;Z)V
-	public synthetic fun <init> (Lkotlin/jvm/functions/Function1;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lkotlin/jvm/functions/Function1;ZLcom/dropbox/differ/ImageComparator;)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function1;ZLcom/dropbox/differ/ImageComparator;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun apply (Lorg/junit/runners/model/Statement;Lorg/junit/runner/Description;)Lorg/junit/runners/model/Statement;
 	public final fun assertSnapshot (Landroid/app/Activity;Ljava/lang/String;)V
 	public final fun assertSnapshot (Landroid/graphics/Bitmap;Ljava/lang/String;)V

--- a/dropshots/src/androidTest/kotlin/com/dropbox/dropshots/CustomImageComparatorTest.kt
+++ b/dropshots/src/androidTest/kotlin/com/dropbox/dropshots/CustomImageComparatorTest.kt
@@ -1,0 +1,59 @@
+package com.dropbox.dropshots
+
+import android.view.View
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import com.dropbox.differ.Image
+import com.dropbox.differ.ImageComparator
+import com.dropbox.differ.ImageComparator.ComparisonResult
+import com.dropbox.differ.Mask
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class CustomImageComparatorTest {
+
+  @get:Rule
+  val activityScenarioRule = ActivityScenarioRule(TestActivity::class.java)
+
+  val comparator = FakeImageComparator()
+
+  @get:Rule
+  val dropshots = Dropshots(recordScreenshots = false, imageComparator = comparator)
+
+  @Before
+  fun setup() {
+    activityScenarioRule.scenario.onActivity {
+      it.supportFragmentManager.beginTransaction()
+        .add(android.R.id.content, ScreenshotTestFragment())
+        .commitNow()
+    }
+  }
+
+  @Test
+  fun imageComparatorIsConfigurable() {
+    val calls = mutableListOf<Triple<Image, Image, Mask?>>()
+    comparator.compareFunc = { left, right, mask ->
+      calls.add(Triple(left, right, mask))
+      ComparisonResult(0, 0, 0, 0)
+    }
+
+    activityScenarioRule.scenario.onActivity {
+      dropshots.assertSnapshot(
+        it.findViewById<View>(android.R.id.content),
+        name = "MatchesViewScreenshot"
+      )
+    }
+
+    // Just making sure that the custom comparator was called.
+    assert(calls.isNotEmpty())
+  }
+}
+
+class FakeImageComparator(
+  var compareFunc: (Image, Image, Mask?) -> ComparisonResult = { _, _, _ ->
+    ComparisonResult(0, 0, 0, 0)
+  }
+) : ImageComparator {
+  override fun compare(left: Image, right: Image, mask: Mask?): ComparisonResult =
+    compareFunc(left, right, mask)
+}

--- a/dropshots/src/main/java/com/dropbox/dropshots/Dropshots.kt
+++ b/dropshots/src/main/java/com/dropbox/dropshots/Dropshots.kt
@@ -12,6 +12,7 @@ import android.view.View
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.GrantPermissionRule
 import androidx.test.runner.screenshot.Screenshot
+import com.dropbox.differ.ImageComparator
 import com.dropbox.differ.Mask
 import com.dropbox.differ.SimpleImageComparator
 import java.io.File
@@ -30,7 +31,11 @@ public class Dropshots(
    * Indicates whether new reference screenshots should be recorded. Otherwise Dropshots performs
    * validation of test screenshots against reference screenshots.
    */
-  private val recordScreenshots: Boolean = isRecordingScreenshots()
+  private val recordScreenshots: Boolean = isRecordingScreenshots(),
+  /**
+   * The `ImageComparator` used to compare test and reference screenshots.
+   */
+  private val imageComparator: ImageComparator = SimpleImageComparator(maxDistance = 0.004f)
 ) : TestRule {
   private val context = InstrumentationRegistry.getInstrumentation().context
   private val targetContext = InstrumentationRegistry.getInstrumentation().targetContext
@@ -104,14 +109,9 @@ public class Dropshots(
       }
     }
 
-    val differ = SimpleImageComparator(
-      maxDistance = 0.004f,
-      hShift = 5,
-      vShift = 5,
-    )
     val mask = Mask(bitmap.width, bitmap.height)
     val result = try {
-      differ.compare(BitmapImage(reference), BitmapImage(bitmap), mask)
+      imageComparator.compare(BitmapImage(reference), BitmapImage(bitmap), mask)
     } catch (e: IllegalArgumentException) {
       writeThen(filename, reference, bitmap, mask) {
         IllegalArgumentException(


### PR DESCRIPTION
Moving the image comparator to a configurable input allows consumers to set specific settings based on their needs.