### PR TITLE
make compatible with config-cache

### DIFF
--- a/dropshots-gradle-plugin/api/dropshots-gradle-plugin.api
+++ b/dropshots-gradle-plugin/api/dropshots-gradle-plugin.api
@@ -2,6 +2,7 @@ public abstract class com/dropbox/dropshots/ClearScreenshotsTask : org/gradle/ap
 	public fun <init> ()V
 	public final fun clearScreenshots ()V
 	public abstract fun getAdbExecutable ()Lorg/gradle/api/provider/Property;
+	protected abstract fun getExecOperations ()Lorg/gradle/process/ExecOperations;
 	public abstract fun getScreenshotDir ()Lorg/gradle/api/provider/Property;
 }
 
@@ -14,6 +15,7 @@ public final class com/dropbox/dropshots/DropshotsPlugin : org/gradle/api/Plugin
 public abstract class com/dropbox/dropshots/PullScreenshotsTask : org/gradle/api/DefaultTask {
 	public fun <init> ()V
 	public abstract fun getAdbExecutable ()Lorg/gradle/api/provider/Property;
+	protected abstract fun getExecOperations ()Lorg/gradle/process/ExecOperations;
 	public abstract fun getOutputDirectory ()Lorg/gradle/api/file/DirectoryProperty;
 	public abstract fun getScreenshotDir ()Lorg/gradle/api/provider/Property;
 	public final fun pullScreenshots ()V

--- a/dropshots-gradle-plugin/src/main/kotlin/com/dropbox/dropshots/ClearScreenshotsTask.kt
+++ b/dropshots-gradle-plugin/src/main/kotlin/com/dropbox/dropshots/ClearScreenshotsTask.kt
@@ -14,6 +14,9 @@ public abstract class ClearScreenshotsTask : DefaultTask() {
   @get:Destroys
   public abstract val screenshotDir: Property<String>
 
+  @Inject
+  protected abstract fun getExecOperations(): ExecOperations
+
   init {
     description = "Removes the test screenshots from the test device."
     group = "verification"
@@ -23,14 +26,14 @@ public abstract class ClearScreenshotsTask : DefaultTask() {
   public fun clearScreenshots() {
     val adb = adbExecutable.get()
     val dir = screenshotDir.get()
-    val checkResult = project.exec {
+    val checkResult = getExecOperations().exec {
       it.executable = adb
       it.args = listOf("shell", "test", "-d", dir)
       it.isIgnoreExitValue = true
     }
 
     if (checkResult.exitValue == 0) {
-      project.exec {
+      getExecOperations().exec {
         it.executable = adb
         it.args = listOf("shell", "rm", "-r", dir)
       }

--- a/dropshots-gradle-plugin/src/main/kotlin/com/dropbox/dropshots/ClearScreenshotsTask.kt
+++ b/dropshots-gradle-plugin/src/main/kotlin/com/dropbox/dropshots/ClearScreenshotsTask.kt
@@ -16,8 +16,8 @@ public abstract class ClearScreenshotsTask : DefaultTask() {
   @get:Destroys
   public abstract val screenshotDir: Property<String>
 
-  @Inject
-  protected abstract fun getExecOperations(): ExecOperations
+  @get:Inject
+  protected abstract val execOperations: ExecOperations
 
   init {
     description = "Removes the test screenshots from the test device."
@@ -28,14 +28,14 @@ public abstract class ClearScreenshotsTask : DefaultTask() {
   public fun clearScreenshots() {
     val adb = adbExecutable.get()
     val dir = screenshotDir.get()
-    val checkResult = getExecOperations().exec {
+    val checkResult = execOperations.exec {
       it.executable = adb
       it.args = listOf("shell", "test", "-d", dir)
       it.isIgnoreExitValue = true
     }
 
     if (checkResult.exitValue == 0) {
-      getExecOperations().exec {
+      execOperations.exec {
         it.executable = adb
         it.args = listOf("shell", "rm", "-r", dir)
       }

--- a/dropshots-gradle-plugin/src/main/kotlin/com/dropbox/dropshots/ClearScreenshotsTask.kt
+++ b/dropshots-gradle-plugin/src/main/kotlin/com/dropbox/dropshots/ClearScreenshotsTask.kt
@@ -1,10 +1,12 @@
 package com.dropbox.dropshots
 
+import javax.inject.Inject
 import org.gradle.api.DefaultTask
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Destroys
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
+import org.gradle.process.ExecOperations
 
 public abstract class ClearScreenshotsTask : DefaultTask() {
 

--- a/dropshots-gradle-plugin/src/main/kotlin/com/dropbox/dropshots/PullScreenshotsTask.kt
+++ b/dropshots-gradle-plugin/src/main/kotlin/com/dropbox/dropshots/PullScreenshotsTask.kt
@@ -21,8 +21,8 @@ public abstract class PullScreenshotsTask : DefaultTask() {
   @get:OutputDirectory
   public abstract val outputDirectory: DirectoryProperty
 
-  @Inject
-  protected abstract fun getExecOperations(): ExecOperations
+  @get:Inject
+  protected abstract val execOperations: ExecOperations
 
   init {
     description = "Pull screenshots from the test device."
@@ -37,7 +37,7 @@ public abstract class PullScreenshotsTask : DefaultTask() {
 
     val adb = adbExecutable.get()
     val dir = screenshotDir.get()
-    val checkResult = getExecOperations().exec {
+    val checkResult = execOperations.exec {
       it.executable = adb
       it.args = listOf("shell", "test", "-d", dir)
       it.isIgnoreExitValue = true
@@ -45,7 +45,7 @@ public abstract class PullScreenshotsTask : DefaultTask() {
 
     if (checkResult.exitValue == 0) {
       val output = ByteArrayOutputStream()
-      getExecOperations().exec {
+      execOperations.exec {
         it.executable = adb
         it.args = listOf("pull", "$dir/.", outputDir.path)
         it.standardOutput = output

--- a/dropshots-gradle-plugin/src/main/kotlin/com/dropbox/dropshots/PullScreenshotsTask.kt
+++ b/dropshots-gradle-plugin/src/main/kotlin/com/dropbox/dropshots/PullScreenshotsTask.kt
@@ -19,6 +19,9 @@ public abstract class PullScreenshotsTask : DefaultTask() {
   @get:OutputDirectory
   public abstract val outputDirectory: DirectoryProperty
 
+  @Inject
+  protected abstract fun getExecOperations(): ExecOperations
+
   init {
     description = "Pull screenshots from the test device."
     group = "verification"
@@ -32,7 +35,7 @@ public abstract class PullScreenshotsTask : DefaultTask() {
 
     val adb = adbExecutable.get()
     val dir = screenshotDir.get()
-    val checkResult = project.exec {
+    val checkResult = getExecOperations().exec {
       it.executable = adb
       it.args = listOf("shell", "test", "-d", dir)
       it.isIgnoreExitValue = true
@@ -40,7 +43,7 @@ public abstract class PullScreenshotsTask : DefaultTask() {
 
     if (checkResult.exitValue == 0) {
       val output = ByteArrayOutputStream()
-      project.exec {
+      getExecOperations().exec {
         it.executable = adb
         it.args = listOf("pull", "$dir/.", outputDir.path)
         it.standardOutput = output

--- a/dropshots-gradle-plugin/src/main/kotlin/com/dropbox/dropshots/PullScreenshotsTask.kt
+++ b/dropshots-gradle-plugin/src/main/kotlin/com/dropbox/dropshots/PullScreenshotsTask.kt
@@ -1,5 +1,6 @@
 package com.dropbox.dropshots
 
+import javax.inject.Inject
 import java.io.ByteArrayOutputStream
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
@@ -7,6 +8,7 @@ import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
+import org.gradle.process.ExecOperations
 
 public abstract class PullScreenshotsTask : DefaultTask() {
 


### PR DESCRIPTION
Minor change to make the plugin compatible with config-cache. 

Used the guide here and help from @joshafeinberg : https://docs.gradle.org/7.5/userguide/configuration_cache.html#config_cache:requirements:use_project_during_execution