### PR TITLE
Added dropshots extension

### DIFF
--- a/dropshots-gradle-plugin/src/main/kotlin/com/dropbox/dropshots/DropshotsExtension.kt
+++ b/dropshots-gradle-plugin/src/main/kotlin/com/dropbox/dropshots/DropshotsExtension.kt
@@ -1,0 +1,9 @@
+package com.dropbox.dropshots
+
+public open class DropshotsExtension {
+  public var referenceDirectory: String = "src/androidTest/screenshots"
+
+  public companion object {
+    public const val EXTENSION_NAME: String = "dropshots"
+  }
+}


### PR DESCRIPTION
As I found a `TODO` in the source code I decided to bring my little contribution.

I am not sure if this `referenceScreenshotDirectory` should only affect recording of screenshots, or validation part too? 
Although I see that it records screenshots to the provided directory, but it still tries to find reference in `src/androidTest/screenshots` during verification