### PR TITLE
Fixes storage permissions on API 29.

### DIFF
--- a/dropshots/src/main/AndroidManifest.xml
+++ b/dropshots/src/main/AndroidManifest.xml
@@ -1,4 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
+
+  <uses-permission
+    android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+    android:maxSdkVersion="29" />
+
+  <application android:requestLegacyExternalStorage="true" />
 </manifest>

--- a/dropshots/src/main/java/com/dropbox/dropshots/Dropshots.kt
+++ b/dropshots/src/main/java/com/dropbox/dropshots/Dropshots.kt
@@ -56,7 +56,7 @@ public class Dropshots(
     className = fqName.substringAfterLast('.', missingDelimiterValue = "")
     testName = description.methodName
 
-    return if (Build.VERSION.SDK_INT <= 28) {
+    return if (Build.VERSION.SDK_INT <= 29) {
       GrantPermissionRule
         .grant(android.Manifest.permission.WRITE_EXTERNAL_STORAGE)
         .apply(base, description)


### PR DESCRIPTION
### Issue
The runtime library is unable to write to the Downloads folder on Android 10 (API 29).  
  
Android 10 is a bit of a special case in terms of scoped storage. It's the first version with scoped storage, but it doesn't have the [direct file paths](https://developer.android.com/training/data-storage/shared/media#direct-file-paths) feature yet, introduced in Android 11, which re-enables the use of the Java File API.  

### Fix
This PR fixes this by setting [requestLegacyExternalStorage](https://developer.android.com/reference/kotlin/android/R.attr#requestLegacyExternalStorage:kotlin.Int) to true and declaring the [WRITE_EXTERNAL_STORAGE](https://developer.android.com/training/data-storage/shared/media#extra-permissions) permission for API 29, so Dropshots can use the Java File API to write to the Downloads folder, or any other media folder. 

Closes #32 