### PR TITLE
Make name param optional in assertSnapshot's overload for bitmaps

### DIFF
--- a/dropshots/src/main/java/com/dropbox/dropshots/Dropshots.kt
+++ b/dropshots/src/main/java/com/dropbox/dropshots/Dropshots.kt
@@ -96,7 +96,7 @@ public class Dropshots(
   @Suppress("LongMethod")
   public fun assertSnapshot(
     bitmap: Bitmap,
-    name: String,
+    name: String = snapshotName,
     filePath: String? = null,
   ) {
     val filename = filenameFunc(name)


### PR DESCRIPTION
As part of my workaround for a [bug related to minSdk <= 23](https://issuetracker.google.com/issues/283219177), I had to migrate all my usages of `assertSnapshot(Activity)` to `assertSnapshot(Bitmap)`. It'd be nice if I could continue not providing an explicit snapshot name for bitmap comparisons. 