### PR TITLE
Fixes plugin tests for versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,15 @@ allprojects {
 
       pomFromGradleProperties()
     }
+
+    publishing {
+      repositories {
+        maven {
+          name = "projectLocalMaven"
+          url = uri(rootProject.layout.buildDirectory.dir("localMaven"))
+        }
+      }
+    }
   }
 }
 

--- a/dropshots-gradle-plugin/build.gradle.kts
+++ b/dropshots-gradle-plugin/build.gradle.kts
@@ -114,3 +114,7 @@ tasks.register("printVersionName") {
     println(VERSION_NAME)
   }
 }
+
+tasks.withType<Test>().configureEach {
+  dependsOn(":dropshots:publishMavenPublicationToProjectLocalMavenRepository")
+}

--- a/dropshots-gradle-plugin/build.gradle.kts
+++ b/dropshots-gradle-plugin/build.gradle.kts
@@ -2,6 +2,9 @@ import com.android.build.gradle.tasks.SourceJarTask
 import com.vanniktech.maven.publish.GradlePlugin
 import com.vanniktech.maven.publish.JavadocJar.Dokka
 import org.gradle.jvm.tasks.Jar
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -62,11 +65,10 @@ tasks.named("compileKotlin").configure {
 }
 
 tasks.withType<KotlinCompile>().configureEach {
-  kotlinOptions {
-    jvmTarget = "11"
-    // Because Gradle's Kotlin handling is stupid, this falls out of date quickly
-    apiVersion = "1.5"
-    languageVersion = "1.5"
+  compilerOptions {
+    jvmTarget.set(JvmTarget.JVM_11)
+    apiVersion.set(KotlinVersion.KOTLIN_1_8)
+    languageVersion.set(KotlinVersion.KOTLIN_1_8)
   }
 }
 

--- a/dropshots-gradle-plugin/src/test/kotlin/com/dropbox/dropshots/DropshotsPluginTest.kt
+++ b/dropshots-gradle-plugin/src/test/kotlin/com/dropbox/dropshots/DropshotsPluginTest.kt
@@ -11,56 +11,66 @@ import org.junit.rules.TemporaryFolder
 
 class DropshotsPluginTest {
 
-  private val agpVersion = "8.7.1"
   @get:Rule val tmpFolder = TemporaryFolder()
 
-  private lateinit var projectDir: File
-  private lateinit var settingsFile: File
   private lateinit var buildFile: File
   private lateinit var gradleRunner: GradleRunner
 
   @Before
   fun setup() {
+    val localMavenRepo = File("../build/localMaven").absolutePath
+    val versionsFilePath = File("../gradle/libs.versions.toml").absolutePath
+
     // Setup project directory
-    projectDir = tmpFolder.newFolder().apply { mkdir() }
-    File(projectDir, "gradle.properties").writeText("android.useAndroidX=true")
-    // language=groovy
-    settingsFile = File(projectDir, "settings.gradle").apply {
-      writeText(
-        """
-          pluginManagement {
-            repositories {
-              gradlePluginPortal()
-              mavenCentral()
-              google()
-            }
-          }
-        """.trimIndent()
-      )
-    }
-    // language=groovy
-    buildFile = File(projectDir, "build.gradle").apply {
-      writeText(
-        """
-          plugins {
-            id("com.android.library") version "$agpVersion"
-            id("com.dropbox.dropshots")
-          }
+    val projectDir = tmpFolder.newFolder().apply { mkdir() }
+    projectDir.resolve("gradle.properties").writeText("android.useAndroidX=true")
 
-          android {
-            namespace = "com.dropbox.dropshots.test.library"
-            compileSdk = 35
-
-            defaultConfig.minSdk = 24
-          }
-
+    projectDir.resolve("settings.gradle").writeText(
+      // language=groovy
+      """
+        pluginManagement {
           repositories {
+            gradlePluginPortal()
             mavenCentral()
             google()
           }
-        """.trimIndent()
-      )
-    }
+        }
+
+        dependencyResolutionManagement {
+          versionCatalogs {
+            libs {
+              from(files("$versionsFilePath"))
+            }
+          }
+
+          repositories {
+            maven {
+              url("$localMavenRepo")
+            }
+            mavenCentral()
+            google()
+          }
+        }
+      """.trimIndent()
+    )
+
+    buildFile = projectDir.resolve("build.gradle")
+    buildFile.writeText(
+      // language=groovy
+      """
+        plugins {
+          alias(libs.plugins.android.library)
+          id("com.dropbox.dropshots")
+        }
+
+        android {
+          namespace = "com.dropbox.dropshots.test.library"
+          compileSdk = 35
+
+          defaultConfig.minSdk = 24
+        }
+      """.trimIndent()
+    )
 
     gradleRunner = GradleRunner.create()
       .withPluginClasspath()
@@ -69,26 +79,30 @@ class DropshotsPluginTest {
 
   @Test
   fun configurationCache() {
-    gradleRunner
+    // first build
+    gradleRunner.withArguments("tasks", "--configuration-cache").build()
+
+    // Cached build
+    val result = gradleRunner
       .withArguments("tasks", "--configuration-cache", "--stacktrace")
       .build()
+    assertThat(result.output).contains("Reusing configuration cache.")
   }
 
   @Test
   fun `applies to library plugins applied after plugin`() {
     val result = gradleRunner
       .withBuildScript(
-        // language = groovy
+        // language=groovy
         """
           plugins {
             id("com.dropbox.dropshots")
-            id("com.android.library") version "$agpVersion"
+            alias(libs.plugins.android.library)
           }
 
           android {
             namespace = "com.dropbox.dropshots.test.library"
             compileSdk = 35
-
             defaultConfig.minSdk = 24
           }
 
@@ -98,7 +112,7 @@ class DropshotsPluginTest {
           }
         """.trimIndent()
       )
-      .withArguments("tasks", "--configuration-cache", "--stacktrace")
+      .withArguments("tasks")
       .build()
     assertThat(result.output).contains("recordDebugAndroidTestScreenshots")
     assertThat(result.output).contains("pullDebugAndroidTestScreenshots")
@@ -107,7 +121,7 @@ class DropshotsPluginTest {
   @Test
   fun `executes marker file push only when record task is run`() {
     val result = gradleRunner
-      .withArguments("recordDebugAndroidTestScreenshots", "--stacktrace")
+      .withArguments("recordDebugAndroidTestScreenshots")
       .build()
     with(result.task(":pushDebugAndroidTestScreenshotMarkerFile")) {
       assertThat(this).isNotNull()
@@ -118,7 +132,7 @@ class DropshotsPluginTest {
   @Test
   fun `skips marker file push only when record task is run`() {
     val result = gradleRunner
-      .withArguments("connectedDebugAndroidTest", "--stacktrace")
+      .withArguments("connectedDebugAndroidTest")
       .build()
     with(result.task(":pushDebugAndroidTestScreenshotMarkerFile")) {
       assertThat(this).isNotNull()

--- a/dropshots/build.gradle.kts
+++ b/dropshots/build.gradle.kts
@@ -1,5 +1,6 @@
 import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
 import java.io.ByteArrayOutputStream
+import java.util.Locale
 
 plugins {
   alias(libs.plugins.android.library)
@@ -66,14 +67,15 @@ val adbExecutablePath = provider { android.adbExecutable.path }
 android.testVariants.all {
   val screenshotDir = "/storage/emulated/0/Download/screenshots/com.dropbox.dropshots.test"
   val connectedAndroidTest = connectedInstrumentTestProvider
+  val variantSlug = name.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }
 
-  val recordScreenshotsTask = tasks.register("record${name.capitalize()}Screenshots")
+  val recordScreenshotsTask = tasks.register("record${variantSlug}Screenshots")
   val isRecordingScreenshots = project.objects.property(Boolean::class.java)
   project.gradle.taskGraph.whenReady {
     isRecordingScreenshots.set(recordScreenshotsTask.map { hasTask(it) })
   }
 
-  val pushMarkerFileTask = tasks.register("push${name.capitalize()}ScreenshotMarkerFile") {
+  val pushMarkerFileTask = tasks.register("push${variantSlug}ScreenshotMarkerFile") {
     description = "Push screenshot marker file to test device."
     group = "verification"
     outputs.upToDateWhen { false }
@@ -92,7 +94,7 @@ android.testVariants.all {
     }
   }
 
-  val setupEmulatorTask = tasks.register("setup${name.capitalize()}ScreenshotEmulator") {
+  val setupEmulatorTask = tasks.register("setup${variantSlug}ScreenshotEmulator") {
     description = "Configures the test device for screenshots."
     group = "verification"
     doLast {
@@ -117,7 +119,7 @@ android.testVariants.all {
       adbCommand("shell am broadcast -a com.android.systemui.demo -e command notifications -e visible false")
     }
   }
-  val restoreEmulatorTask = tasks.register("restore${name.capitalize()}ScreenshotEmulator") {
+  val restoreEmulatorTask = tasks.register("restore${variantSlug}ScreenshotEmulator") {
     description = "Restores the test device from screenshot mode."
     group = "verification"
     doLast {
@@ -128,7 +130,7 @@ android.testVariants.all {
     }
   }
 
-  val pullScreenshotsTask = tasks.register("pull${name.capitalize()}Screenshots") {
+  val pullScreenshotsTask = tasks.register("pull${variantSlug}Screenshots") {
     description = "Pull screenshots from the test device."
     group = "verification"
     outputs.dir(project.layout.buildDirectory.dir("reports/androidTests/dropshots"))

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.dropbox.dropshots
-VERSION_NAME=0.5.0-SHAPSHOT
+VERSION_NAME=0.5.0-SNAPSHOT
 
 POM_URL=https://github.com/dropbox/dropshots
 POM_SCM_URL=https://github.com/dropbox/dropshots

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,15 +1,13 @@
 [versions]
 kotlin = "1.9.20"
-agp = "8.7.1"
+agp = "8.7.2"
 
 [libraries]
 android = { module = "com.android.tools.build:gradle", version.ref = "agp" }
-androidx-activity = { module = "androidx.activity:activity-ktx", version = "1.9.3" }
-androidx-annotation = { module = "androidx.annotation:annotation", version = "1.9.0" }
+androidx-annotation = { module = "androidx.annotation:annotation", version = "1.9.1" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version = "1.7.0" }
-androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version = "2.1.4" }
-androidx-core = { module = "androidx.core:core-ktx", version = "1.13.1" }
-androidx-fragment = { module = "androidx.fragment:fragment-ktx", version = "1.8.4" }
+androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version = "2.2.0" }
+androidx-fragment = { module = "androidx.fragment:fragment-ktx", version = "1.8.5" }
 androidx-test-core = { module = "androidx.test:core-ktx", version = "1.6.1" }
 androidx-test-ext-junit = { module = "androidx.test.ext:junit-ktx", version = "1.2.1" }
 androidx-test-rules = { module = "androidx.test:rules", version = "1.6.1" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,6 @@ dokka = { id = "org.jetbrains.dokka", version = "1.9.20" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version = "11.4.2" }
-mavenPublish = { id = "com.vanniktech.maven.publish.base", version = "0.29.0" }
+mavenPublish = { id = "com.vanniktech.maven.publish.base", version = "0.30.0" }
 binaryCompatibilityValidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version = "0.13.0" }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
The plugin adds the dropshots lib as a dependency, but when we update the snapshot version the library isn't in maven, so the tests can't find it. This fixes that by making plugin tests dependent on the dropshots in a project local maven repository.