### PR TITLE
MF-6579 Pull reference images on failure

### DIFF
--- a/dropshots-gradle-plugin/api/dropshots-gradle-plugin.api
+++ b/dropshots-gradle-plugin/api/dropshots-gradle-plugin.api
@@ -6,6 +6,11 @@ public abstract class com/dropbox/dropshots/ClearScreenshotsTask : org/gradle/ap
 	public abstract fun getScreenshotDir ()Lorg/gradle/api/provider/Property;
 }
 
+public abstract class com/dropbox/dropshots/DropshotsExtension {
+	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
+	public final fun getReferenceOutputDirectory ()Lorg/gradle/api/provider/Property;
+}
+
 public final class com/dropbox/dropshots/DropshotsPlugin : org/gradle/api/Plugin {
 	public fun <init> ()V
 	public synthetic fun apply (Ljava/lang/Object;)V

--- a/dropshots-gradle-plugin/src/main/kotlin/com/dropbox/dropshots/DropshotsExtension.kt
+++ b/dropshots-gradle-plugin/src/main/kotlin/com/dropbox/dropshots/DropshotsExtension.kt
@@ -1,0 +1,15 @@
+package com.dropbox.dropshots
+
+import javax.inject.Inject
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+
+public abstract class DropshotsExtension @Inject constructor(objects: ObjectFactory) {
+  /**
+   * Relative to the module's (sub-project) directory, this is where all reference screenshots
+   * (and any sub directories specified through [com.dropbox.dropshots.Dropshots.assertSnapshot])
+   * will be saved.
+   */
+  public val referenceOutputDirectory: Property<String> = objects.property(String::class.java)
+    .convention("src/androidTest/screenshots")
+}

--- a/dropshots-gradle-plugin/src/main/kotlin/com/dropbox/dropshots/DropshotsPlugin.kt
+++ b/dropshots-gradle-plugin/src/main/kotlin/com/dropbox/dropshots/DropshotsPlugin.kt
@@ -88,6 +88,7 @@ public class DropshotsPlugin : Plugin<Project> {
         "record${variantSlug}Screenshots",
         Copy::class.java,
       ) {
+        it.group = "verification"
         it.description = "Updates the local reference screenshots"
         it.from(
           testTaskProvider.flatMap {

--- a/dropshots-gradle-plugin/src/main/kotlin/com/dropbox/dropshots/DropshotsPlugin.kt
+++ b/dropshots-gradle-plugin/src/main/kotlin/com/dropbox/dropshots/DropshotsPlugin.kt
@@ -74,7 +74,7 @@ public class DropshotsPlugin : Plugin<Project> {
         it.screenshotDir.set(screenshotDir)
       }
 
-      val pullScreenshotTask = tasks.register(
+      val pullScreenshotsTask = tasks.register(
         "pull${variantSlug}Screenshots",
         PullScreenshotsTask::class.java,
       ) {
@@ -96,7 +96,7 @@ public class DropshotsPlugin : Plugin<Project> {
           }
         )
         it.into(referenceScreenshotDirectory)
-        it.dependsOn(testTaskProvider, pullScreenshotTask)
+        it.dependsOn(testTaskProvider, pullScreenshotsTask)
         it.finalizedBy(clearScreenshotsTask)
       }
 
@@ -123,7 +123,7 @@ public class DropshotsPlugin : Plugin<Project> {
       testTaskProvider.dependsOn(writeMarkerFileTask)
 
       testTaskProvider.configure {
-        it.finalizedBy(pullScreenshotTask)
+        it.finalizedBy(pullScreenshotsTask)
       }
     }
   }

--- a/dropshots-gradle-plugin/src/main/kotlin/com/dropbox/dropshots/DropshotsPlugin.kt
+++ b/dropshots-gradle-plugin/src/main/kotlin/com/dropbox/dropshots/DropshotsPlugin.kt
@@ -81,7 +81,6 @@ public class DropshotsPlugin : Plugin<Project> {
         it.adbExecutable.set(adbExecutablePath)
         it.screenshotDir.set(screenshotDir)
         it.outputDirectory.set(testTaskProvider.flatMap { (it as AndroidTestTask).resultsDir })
-        it.mustRunAfter(testTaskProvider)
         it.finalizedBy(clearScreenshotsTask)
       }
 
@@ -96,7 +95,7 @@ public class DropshotsPlugin : Plugin<Project> {
           }
         )
         it.into(referenceScreenshotDirectory)
-        it.dependsOn(testTaskProvider, pullScreenshotsTask)
+        it.dependsOn(pullScreenshotsTask)
         it.finalizedBy(clearScreenshotsTask)
       }
 

--- a/dropshots-gradle-plugin/src/test/kotlin/com/dropbox/dropshots/DropshotsPluginTest.kt
+++ b/dropshots-gradle-plugin/src/test/kotlin/com/dropbox/dropshots/DropshotsPluginTest.kt
@@ -140,6 +140,49 @@ class DropshotsPluginTest {
     }
   }
 
+  @Test
+  fun `specifying output directory in extension returns src_test_screenshots`() {
+    val result = gradleRunner
+      .withBuildScript(
+        // language=groovy
+        """
+          plugins {
+            id("com.dropbox.dropshots")
+            alias(libs.plugins.android.library)
+          }
+
+          dropshots {
+              referenceOutputDirectory = "src/test"
+          }
+
+          android {
+            namespace = "com.dropbox.dropshots.test.library"
+            compileSdk = 35
+            defaultConfig.minSdk = 24
+          }
+
+          repositories {
+            mavenCentral()
+            google()
+          }
+
+          dropshots {
+              referenceOutputDirectory.set("test/example")
+          }
+
+          tasks.register("printOutputDirectory") {
+              doLast {
+                  println(dropshots.referenceOutputDirectory.get())
+              }
+          }
+        """.trimIndent()
+      )
+      .withArguments("printOutputDirectory")
+      .build()
+    assertThat(result.output).contains("test/example")
+  }
+
+
   private fun GradleRunner.withBuildScript(buildScript: String): GradleRunner {
     buildFile.writeText(buildScript)
     return this

--- a/dropshots/api/dropshots.api
+++ b/dropshots/api/dropshots.api
@@ -1,10 +1,10 @@
 public final class com/dropbox/dropshots/Dropshots : org/junit/rules/TestRule {
 	public fun <init> ()V
-	public fun <init> (Lkotlin/jvm/functions/Function1;)V
-	public fun <init> (Lkotlin/jvm/functions/Function1;Z)V
-	public fun <init> (Lkotlin/jvm/functions/Function1;ZLcom/dropbox/differ/ImageComparator;)V
-	public fun <init> (Lkotlin/jvm/functions/Function1;ZLcom/dropbox/differ/ImageComparator;Lkotlin/jvm/functions/Function1;)V
-	public synthetic fun <init> (Lkotlin/jvm/functions/Function1;ZLcom/dropbox/differ/ImageComparator;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lkotlin/jvm/functions/Function2;)V
+	public fun <init> (Lkotlin/jvm/functions/Function2;Z)V
+	public fun <init> (Lkotlin/jvm/functions/Function2;ZLcom/dropbox/differ/ImageComparator;)V
+	public fun <init> (Lkotlin/jvm/functions/Function2;ZLcom/dropbox/differ/ImageComparator;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function2;ZLcom/dropbox/differ/ImageComparator;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun apply (Lorg/junit/runners/model/Statement;Lorg/junit/runner/Description;)Lorg/junit/runners/model/Statement;
 	public final fun assertSnapshot (Landroid/app/Activity;Ljava/lang/String;Ljava/lang/String;)V
 	public final fun assertSnapshot (Landroid/graphics/Bitmap;Ljava/lang/String;Ljava/lang/String;)V

--- a/dropshots/src/androidTest/kotlin/com/dropbox/dropshots/DropshotsTest.kt
+++ b/dropshots/src/androidTest/kotlin/com/dropbox/dropshots/DropshotsTest.kt
@@ -24,7 +24,7 @@ class DropshotsTest {
   val activityScenarioRule = ActivityScenarioRule(TestActivity::class.java)
 
   private val fakeValidator = FakeResultValidator()
-  private var filenameFunc: (String) -> String = { it }
+  private var filenameFunc: (String, String) -> String = { _, funcName -> funcName }
   private val isRecordingScreenshots = isRecordingScreenshots(defaultRootScreenshotDirectory())
   private lateinit var imageDirectory: File
 

--- a/dropshots/src/main/java/com/dropbox/dropshots/Dropshots.kt
+++ b/dropshots/src/main/java/com/dropbox/dropshots/Dropshots.kt
@@ -120,7 +120,6 @@ public class Dropshots internal constructor(
     name: String = snapshotName,
     filePath: String? = null,
   ) {
-    // Some CI filesystems don't support spaces in artifact names so we also have to replace them with underscores.
     val filename = filenameFunc(className, name)
 
     val reference = try {

--- a/dropshots/src/main/java/com/dropbox/dropshots/Dropshots.kt
+++ b/dropshots/src/main/java/com/dropbox/dropshots/Dropshots.kt
@@ -223,7 +223,7 @@ public class Dropshots internal constructor(
     val file = File(dir, "${name.replace(" ", "_")}.png")
     if (file.exists()){
       throw IllegalStateException("Unable to create screenshot, file already exists. Please " +
-        "override fileName when calling assertSnapshot and include qualifiers in your file name.")
+        "specify name param with something more specific when calling assertSnapshot function")
     }
 
     file.outputStream().use {

--- a/dropshots/src/main/java/com/dropbox/dropshots/Dropshots.kt
+++ b/dropshots/src/main/java/com/dropbox/dropshots/Dropshots.kt
@@ -39,7 +39,7 @@ public class Dropshots internal constructor(
   @JvmOverloads
   public constructor(
     /**
-     * Function to create a filename from a snapshot name (i.e. the name provided when taking
+     * Function to create a filename from the class name and snapshot name (i.e. the name provided when taking
      * the snapshot). Default behavior will use the calling function name.
      */
     filenameFunc: (String, String) -> String = defaultFilenameFunc,

--- a/dropshots/src/main/java/com/dropbox/dropshots/Dropshots.kt
+++ b/dropshots/src/main/java/com/dropbox/dropshots/Dropshots.kt
@@ -7,6 +7,7 @@ import android.graphics.Canvas
 import android.graphics.Paint
 import android.os.Build
 import android.os.Environment
+import android.util.Base64
 import android.view.View
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.GrantPermissionRule
@@ -22,6 +23,7 @@ import org.junit.runners.model.Statement
 
 public class Dropshots internal constructor(
   private val rootScreenshotDirectory: File,
+  private val filenameFunc: (String, String) -> String,
   private val recordScreenshots: Boolean,
   private val imageComparator: ImageComparator,
   private val resultValidator: ResultValidator,
@@ -32,8 +34,15 @@ public class Dropshots internal constructor(
   private var className: String = ""
   private var testName: String = ""
 
+  private val snapshotName: String get() = testName
+
   @JvmOverloads
   public constructor(
+    /**
+     * Function to create a filename from a snapshot name (i.e. the name provided when taking
+     * the snapshot). Default behavior will use the calling function name.
+     */
+    filenameFunc: (String, String) -> String = defaultFilenameFunc,
     /**
      * Indicates whether new reference screenshots should be recorded. Otherwise Dropshots performs
      * validation of test screenshots against reference screenshots.
@@ -47,7 +56,7 @@ public class Dropshots internal constructor(
      * The `ResultValidator` used to validate the comparison results.
      */
     resultValidator: ResultValidator = CountValidator(0),
-  ): this(defaultRootScreenshotDirectory(), recordScreenshots, imageComparator, resultValidator)
+  ): this(defaultRootScreenshotDirectory(), filenameFunc, recordScreenshots, imageComparator, resultValidator)
 
   override fun apply(base: Statement, description: Description): Statement {
     fqName = description.className
@@ -70,35 +79,27 @@ public class Dropshots internal constructor(
    * If `BuildConfig.IS_RECORD_SCREENSHOTS` is set to `true`, then the screenshot will simply be written
    * to disk to be pulled to the host machine to update the reference images.
    *
-   * @param name lambda to create a filename from the snapshot name (i.e. the name provided when
-   * taking the snapshot), first parameter is the class name and the second is the test name.
-   * Defaults to `<class-name>_<func-name>.png` limited to 255 chars, replacing all spaces with underscores.
-   * @param filePath where the screenshots should be store in project under [com.dropbox.dropshots.DropshotsExtension.referenceOutputDirectory]
+   * @param filePath where the screenshots should be store in project eg. "views/colors"
    */
-  @Deprecated("Use assertSnapshot(view: View, fileName: (String, String) -> String, filePath: String?) instead")
   public fun assertSnapshot(
     view: View,
-    name: String,
+    name: String = snapshotName,
     filePath: String? = null,
-  ): Unit = assertSnapshot(Screenshot.capture(view).bitmap, { _, _ -> name }, filePath)
+  ): Unit = assertSnapshot(Screenshot.capture(view).bitmap, name, filePath)
 
   /**
-   * Compares a screenshot of the [Activity] to a reference screenshot from the test application's assets.
+   * Compares a screenshot of the activity to a reference screenshot from the test application's assets.
    *
    * If `BuildConfig.IS_RECORD_SCREENSHOTS` is set to `true`, then the screenshot will simply be written
    * to disk to be pulled to the host machine to update the reference images.
    *
-   * @param name lambda to create a filename from the snapshot name (i.e. the name provided when
-   * taking the snapshot), first parameter is the class name and the second is the test name.
-   * Defaults to `<class-name>_<func-name>.png` limited to 255 chars, replacing all spaces with underscores.
-   * @param filePath where the screenshots should be store in project under [com.dropbox.dropshots.DropshotsExtension.referenceOutputDirectory]
+   * @param filePath where the screenshots should be store in project eg. "views/colors"
    */
-  @Deprecated("Use assertSnapshot(activity: Activity, fileName: (String, String) -> String, filePath: String?) instead")
   public fun assertSnapshot(
     activity: Activity,
-    name: String,
+    name: String = snapshotName,
     filePath: String? = null,
-  ): Unit = assertSnapshot(Screenshot.capture(activity).bitmap, { _, _ -> name }, filePath)
+  ): Unit = assertSnapshot(Screenshot.capture(activity).bitmap, name, filePath)
 
   /**
    * Compares a screenshot of the visible screen content to a reference screenshot from the test application's assets.
@@ -106,112 +107,21 @@ public class Dropshots internal constructor(
    * If `BuildConfig.IS_RECORD_SCREENSHOTS` is set to `true`, then the screenshot will simply be written
    * to disk to be pulled to the host machine to update the reference images.
    *
-   * @param name lambda to create a filename from the snapshot name (i.e. the name provided when
-   * taking the snapshot), first parameter is the class name and the second is the test name.
-   * Defaults to `<class-name>_<func-name>.png` limited to 255 chars, replacing all spaces with underscores.
-   * @param filePath where the screenshots should be store in project under [com.dropbox.dropshots.DropshotsExtension.referenceOutputDirectory]
+   * @param filePath where the screenshots should be store in project eg. "views/colors"
    */
-  @Deprecated("Use assertSnapshot(fileName: (String, String) -> String, filePath: String?) instead")
   public fun assertSnapshot(
-    name: String,
+    name: String = snapshotName,
     filePath: String? = null,
-  ): Unit = assertSnapshot(Screenshot.capture().bitmap, { _, _ -> name }, filePath)
+  ): Unit = assertSnapshot(Screenshot.capture().bitmap, name, filePath)
 
-
-  /**
-   * Compares a [bitmap] to a reference screenshot from the test application's assets.
-   *
-   * If `BuildConfig.IS_RECORD_SCREENSHOTS` is set to `true`, then the screenshot will simply be written
-   * to disk to be pulled to the host machine to update the reference images.
-   *
-   * @param bitmap the bitmap to assert
-   * @param name lambda to create a filename from the snapshot name (i.e. the name provided when
-   * taking the snapshot), first parameter is the class name and the second is the test name.
-   * Defaults to `<class-name>_<func-name>.png` limited to 255 chars, replacing all spaces with underscores.
-   * @param filePath where the screenshots should be store in project under [com.dropbox.dropshots.DropshotsExtension.referenceOutputDirectory]
-   */
-  @Deprecated("Use assertSnapshot(fileName: (String, String) -> String, filePath: String?) instead")
   @Suppress("LongMethod")
   public fun assertSnapshot(
     bitmap: Bitmap,
-    name: String,
-    filePath: String? = null,
-  ) : Unit = assertSnapshot(bitmap, { _, _ -> name }, filePath)
-
-  /**
-   * Compares a screenshot of the view to a reference screenshot from the test application's assets.
-   *
-   * If `BuildConfig.IS_RECORD_SCREENSHOTS` is set to `true`, then the screenshot will simply be written
-   * to disk to be pulled to the host machine to update the reference images.
-   *
-   * @param fileName lambda to create a filename from the snapshot name (i.e. the name provided when
-   * taking the snapshot), first parameter is the class name and the second is the test name.
-   * Defaults to `<class-name>_<func-name>.png` limited to 255 chars, replacing all spaces with underscores.
-   * @param filePath where the screenshots should be store in project under [com.dropbox.dropshots.DropshotsExtension.referenceOutputDirectory]
-   */
-  public fun assertSnapshot(
-    view: View,
-    fileName: (String, String) -> String = defaultFilenameFunc,
-    filePath: String? = null,
-  ): Unit = assertSnapshot(Screenshot.capture(view).bitmap, fileName, filePath)
-
-  /**
-   * Compares a screenshot of the [Activity] to a reference screenshot from the test application's assets.
-   *
-   * If `BuildConfig.IS_RECORD_SCREENSHOTS` is set to `true`, then the screenshot will simply be written
-   * to disk to be pulled to the host machine to update the reference images.
-   *
-   * @param fileName lambda to create a filename from the snapshot name (i.e. the name provided when
-   * taking the snapshot), first parameter is the class name and the second is the test name.
-   * Defaults to `<class-name>_<func-name>.png` limited to 255 chars, replacing all spaces with underscores.
-   * @param filePath where the screenshots should be store in project under [com.dropbox.dropshots.DropshotsExtension.referenceOutputDirectory]
-   */
-  public fun assertSnapshot(
-    activity: Activity,
-    fileName: (String, String) -> String = defaultFilenameFunc,
-    filePath: String? = null,
-  ): Unit = assertSnapshot(Screenshot.capture(activity).bitmap, fileName, filePath)
-
-  /**
-   * Compares a screenshot of the visible screen content to a reference screenshot from the test application's assets.
-   *
-   * If `BuildConfig.IS_RECORD_SCREENSHOTS` is set to `true`, then the screenshot will simply be written
-   * to disk to be pulled to the host machine to update the reference images.
-   *
-   * @param fileName lambda to create a filename from the snapshot name (i.e. the name provided when
-   * taking the snapshot), first parameter is the class name and the second is the test name.
-   * Defaults to `<class name>_<func-name>.png` limited to 255 chars, replacing all spaces with underscores.
-   * @param filePath where the screenshots should be store in project under [com.dropbox.dropshots.DropshotsExtension.referenceOutputDirectory]
-   */
-  public fun assertSnapshot(
-    fileName: (String, String) -> String = defaultFilenameFunc,
-    filePath: String? = null,
-  ): Unit = assertSnapshot(Screenshot.capture().bitmap, fileName, filePath)
-
-
-  /**
-   * Compares a [bitmap] to a reference screenshot from the test application's assets.
-   *
-   * If `BuildConfig.IS_RECORD_SCREENSHOTS` is set to `true`, then the screenshot will simply be written
-   * to disk to be pulled to the host machine to update the reference images.
-   *
-   * @param bitmap the bitmap to assert
-   * @param fileName lambda to create a filename from the snapshot name (i.e. the name provided when
-   * taking the snapshot), first parameter is the class name and the second is the test name.
-   * Defaults to `<class name>_<func-name>.png` limited to 255 chars, replacing all spaces with underscores.
-   * @param filePath where the screenshots should be store in project under [com.dropbox.dropshots.DropshotsExtension.referenceOutputDirectory]
-   */
-  @Suppress("LongMethod")
-  public fun assertSnapshot(
-    bitmap: Bitmap,
-    fileName: (String, String) -> String = defaultFilenameFunc,
+    name: String = snapshotName,
     filePath: String? = null,
   ) {
     // Some CI filesystems don't support spaces in artifact names so we also have to replace them with underscores.
-    val filename = fileName(className, testName).replace(" ", "_")
-    require(filename.length < 255 - "_diff".length){
-      "Screenshot file-name exceeds max length: $filename"
-    }
+    val filename = filenameFunc(className, name)
 
     val reference = try {
       context.assets.open("$filename.png".prependPath(filePath)).use {
@@ -223,7 +133,9 @@ public class Dropshots internal constructor(
       if (!recordScreenshots) {
         throw IllegalStateException(
           "Failed to find reference image named /$filename.png at path $filePath . " +
-            "If this is a new test, you may need to record screenshots by running the record<variantSlug>Screenshots gradle task",
+            "If this is a new test, you may need to record screenshots by running " +
+            "record<variantSlug>Screenshots gradle task or pulling screenshots " +
+            "from a previous run using pull<variantSlug>Screenshots gradle task",
           e
         )
       }
@@ -237,7 +149,7 @@ public class Dropshots internal constructor(
       if (!recordScreenshots) {
         val outputPath = writeDiffImage(filename, filePath, bitmap, reference, null)
         throw AssertionError(
-          "$filename: Test image (w=${bitmap.width}, h=${bitmap.height}) differs in size" +
+          "$name: Test image (w=${bitmap.width}, h=${bitmap.height}) differs in size" +
             " from reference image (w=${reference.width}, h=${reference.height}).\n" +
             "Diff written to: $outputPath",
         )
@@ -270,7 +182,7 @@ public class Dropshots internal constructor(
       if (!recordScreenshots) {
         val outputPath = writeDiffImage(filename, filePath, bitmap, reference, mask)
         throw AssertionError(
-          "\"$filename\" failed to match reference image. ${result.pixelDifferences} pixels differ " +
+          "\"$name\" failed to match reference image. ${result.pixelDifferences} pixels differ " +
             "(${(result.pixelDifferences / result.pixelCount.toFloat()) * 100} %)\n" +
             "Output written to: $outputPath"
         )
@@ -300,16 +212,15 @@ public class Dropshots internal constructor(
   ): String {
     val screenshotFolder = File(rootScreenshotDirectory, "diff".appendPath(filePath))
     val diffImage = generateDiffImage(referenceImage, screenshot, mask)
-    return writeImage(screenshotFolder, name, diffImage, "_diff")
+    return writeImage(screenshotFolder, name, diffImage)
   }
 
-  private fun writeImage(dir: File, name: String, image: Bitmap, nameSuffix: String = ""): String {
+  private fun writeImage(dir: File, name: String, image: Bitmap): String {
     if (!dir.exists() && !dir.mkdirs()) {
       throw IllegalStateException("Unable to create screenshot storage directory.")
     }
 
-    val file = File(dir, "${name.replace(" ", "_")}$nameSuffix.png")
-
+    val file = File(dir, "${name.replace(" ", "_")}.png")
     if (file.exists()){
       throw IllegalStateException("Unable to create screenshot, file already exists. Please " +
         "override fileName when calling assertSnapshot and include qualifiers in your file name.")
@@ -382,13 +293,23 @@ internal fun isRecordingScreenshots(rootScreenshotDirectory: File): Boolean {
 }
 
 /**
- * Creates a filename from class-name and test-name of where the screenshot was taken.
+ * Creates a filename from the requested name that'll be 64 characters or less.
+ *
+ * If the requested name is longer that 64 characters, it'll be shortened by
+ * encoding the end of the name, leaving the beginning in tact to hopefully provide
+ * somewhat human readable names while still trying to prevent collisions.
  */
-internal val defaultFilenameFunc = { className: String?, testName: String ->
-  if (className.isNullOrEmpty()){
+internal val defaultFilenameFunc = { _: String, testName: String ->
+  if (testName.length < 64) {
     testName
   } else {
-    "${className}_${testName}"
+    val prefix = testName.substring(0, 32)
+    val suffix = String(Base64.encode(testName.substring(32).toByteArray(), Base64.DEFAULT)).trim()
+    "${prefix}_$suffix"
+  }.let {
+    // Some CI filesystems don't support spaces in artifact names so we also have to
+    // replace them with underscores.
+    it.replace(" ", "_")
   }
 }
 


### PR DESCRIPTION
- Adds DropshotsExtension.kt to specify referenceOutputDirectory
- Fail task when snapshot file already exist to prevent accidental file overrides
- Pull both diff and reference directories on cAT failure