### PR TITLE
Update project property usage pattern.

### DIFF
--- a/dropshots-gradle-plugin/src/main/kotlin/com/dropbox/dropshots/DropshotsPlugin.kt
+++ b/dropshots-gradle-plugin/src/main/kotlin/com/dropbox/dropshots/DropshotsPlugin.kt
@@ -101,7 +101,7 @@ public class DropshotsPlugin : Plugin<Project> {
       }
 
       val isRecordingScreenshots = project.objects.property(Boolean::class.java)
-      if (hasProperty(recordScreenshotsArg)) {
+      if (providers.gradleProperty(recordScreenshotsArg).isPresent) {
         project.logger.warn("The 'dropshots.record' property has been deprecated and will " +
           "be removed in a future version.")
         isRecordingScreenshots.set(true)

--- a/dropshots-gradle-plugin/src/test/kotlin/com/dropbox/dropshots/DropshotsPluginTest.kt
+++ b/dropshots-gradle-plugin/src/test/kotlin/com/dropbox/dropshots/DropshotsPluginTest.kt
@@ -182,6 +182,35 @@ class DropshotsPluginTest {
     assertThat(result.output).contains("test/example")
   }
 
+  @Test
+  fun `dropshot record shows a deprecated warning`() {
+    val result = gradleRunner
+      .withBuildScript(
+        // language=groovy
+        """
+          plugins {
+            id("com.dropbox.dropshots")
+            alias(libs.plugins.android.library)
+          }
+
+          android {
+            namespace = "com.dropbox.dropshots.test.library"
+            compileSdk = 35
+            defaultConfig.minSdk = 24
+          }
+
+          repositories {
+            mavenCentral()
+            google()
+          }
+        """.trimIndent()
+      )
+      .withArguments("tasks", "-Pdropshots.record")
+      .build()
+    assertThat(result.output).contains("The 'dropshots.record' property has been deprecated and will " +
+      "be removed in a future version.")
+  }
+
 
   private fun GradleRunner.withBuildScript(buildScript: String): GradleRunner {
     buildFile.writeText(buildScript)


### PR DESCRIPTION
Replaces hasProperty with providers.gradleProperty.isPresent to make compatible with isolated projects.

I know dropshot.record is set to be removed, but I'm not sure what the timeline is.